### PR TITLE
git log from v.1.4 branch

### DIFF
--- a/version_checker/lib/mix/version_checker.run.ex
+++ b/version_checker/lib/mix/version_checker.run.ex
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.VersionChecker.Run do
   """
   def get_latest_hash(repo_dir, filepath) do
     args =
-      ~s(--git-dir #{repo_dir}/.git log -n 1 --pretty=format:"%h" -- #{filepath})
+      ~s(--git-dir #{repo_dir}/.git log --first-parent remotes/origin/v1.4 -n 1 --pretty=format:"%h" -- #{filepath})
       |> String.split(" ")
 
     {commit_short_hash, 0} = System.cmd("git", args)


### PR DESCRIPTION
# 概要
- v1.4ブランチのlogを取るように修正
- v.1.5がリリースされ、v.1.4とv1.5の翻訳が共存するようになったらここも修正が必要
- 現時点ではv1.4で決め打ちで動かしておく


# Issue
