### PR TITLE
exclude vendor directory.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ description: ElixirのWebフレームワークPhoenixのガイド
 url: "https://fukuoka-ex.github.io"
 baseurl: "/phoenix-guide-ja"
 theme: just-the-docs
-exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "package.json", "package-lock.json",  "script/", "LICENSE.txt", "lib/", "bin/", "README.md", "Rakefile", "version_checker", "docs"]
+exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "package.json", "package-lock.json",  "script/", "LICENSE.txt", "lib/", "bin/", "README.md", "Rakefile", "version_checker", "docs", "vendor/"]
 search_enabled: true
 plugins:
   - jekyll-seo-tag


### PR DESCRIPTION
# 概要
I used 'bundle install --path vendor/bundle'.
This causes the below error.
https://github.com/jekyll/jekyll/issues/5267
Would you please see it?
It would be nice to be merged.

# Issue
Nothing...
Using 'bundle install --path vendor/bundle' causes the problem when he runs `bundle exec jekyll s`.
